### PR TITLE
CHORE: Format date/time for public case submissions in 'All Cases' viewer.

### DIFF
--- a/pages/2_All Cases.py
+++ b/pages/2_All Cases.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from pages.helper import db_queries
 from pages.helper.streamlit_helpers import require_login
-
+from datetime import datetime
 
 def case_viewer(case):
     case = list(case)
@@ -49,6 +49,15 @@ def public_case_viewer(case: list) -> None:
     ):
         if text == "Status":
             value = "Found" if value == "F" else "Not Found"
+        
+        if text == "Submitted on": 
+            try:
+                # Assuming value is an ISO-formatted string from DB (e.g., 'YYYY-MM-DD HH:MM:SS.SSSSSS')
+                dt_object = datetime.fromisoformat(str(value)) 
+                value = dt_object.strftime("%b %d, %Y at %I:%M %p") # Format: Nov 28, 2025 at 04:30 PM
+            except ValueError:
+                # Handle cases where the date format is unexpected
+                value = str(value) + " (Format Error)"
 
         data_col.write(f"{text}: {value}")
 


### PR DESCRIPTION
This PR introduces a minor quality-of-life improvement for the application operators viewing case data.
Modified the public_case_viewer function in 2_All Cases.py.
Imported the standard Python datetime module.

The raw database value for the "Submitted on" field is now formatted into a clear, human-readable string (e.g., "Nov 28, 2025 at 04:30 PM").

This enhances readability and consistency when reviewing public case submissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced submission date display formatting with graceful error handling for invalid date formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->